### PR TITLE
[Epic 1] Configure external assets and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,27 @@
 
 ## Introduction
 
-**smagala/denver** is a bioinformatics pipeline that ...
+**smagala/denver** is a bioinformatics pipeline for analyzing Dengue virus (DENV) Illumina sequencing data. It maps reads against multiple serotype references (DENV1-4 plus sylvatic variants), generates consensus sequences, identifies intra-host variants (iSNVs), and produces quality control visualizations.
 
-<!-- TODO nf-core:
-   Complete this sentence with a 2-3 sentence summary of what types of data the pipeline ingests, a brief overview of the
-   major pipeline sections and the types of output it produces. You're giving an overview to someone new
-   to nf-core here, in 15-20 seconds. For an example, see https://github.com/nf-core/rnaseq/blob/master/README.md#introduction
--->
+This pipeline is a ph-core compliant NextFlow port of the [DENV_pipeline](https://bmcgenomics.biomedcentral.com/articles/10.1186/s12864-024-10350-x) originally developed by Verity Hill & Chrispin Chaguza at the Grubaugh Lab.
 
-<!-- TODO nf-core: Include a figure that guides the user through the major workflow steps. Many nf-core
-     workflows use the "tube map" design for that. See https://nf-co.re/docs/guidelines/graphic_design/workflow_diagrams#examples for examples.   -->
-<!-- TODO nf-core: Fill in short bullet-pointed list of the default steps in the pipeline -->1. Read QC ([`FastQC`](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/))2. Present QC for raw reads ([`MultiQC`](http://multiqc.info/))
+### Pipeline Steps
+
+1. Read QC ([`FastQC`](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/))
+2. Read mapping to multiple serotype references ([`BWA MEM`](https://github.com/lh3/bwa))
+3. Primer trimming ([`iVar trim`](https://andersen-lab.github.io/ivar/html/))
+4. Consensus sequence generation ([`iVar consensus`](https://andersen-lab.github.io/ivar/html/))
+5. Consensus alignment ([`MAFFT`](https://mafft.cbrc.jp/alignment/software/))
+6. Serotype calling based on coverage threshold
+7. Variant calling ([`iVar variants`](https://andersen-lab.github.io/ivar/html/))
+8. Depth profiling ([`bedtools genomecov`](https://bedtools.readthedocs.io/))
+9. QC visualization (variant plots, coverage summaries)
+10. Aggregate reporting ([`MultiQC`](http://multiqc.info/))
 
 ## Usage
 
 > [!NOTE]
 > If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/usage/installation) on how to set-up Nextflow. Make sure to [test your setup](https://nf-co.re/docs/usage/introduction#how-to-run-a-pipeline) with `-profile test` before running the workflow on actual data.
-
-<!-- TODO nf-core: Describe the minimum required steps to execute the pipeline, e.g. how to prepare samplesheets.
-     Explain what rows and columns represent. For instance (please edit as appropriate):
 
 First, prepare a samplesheet with your input data that looks as follows:
 
@@ -40,12 +42,31 @@ First, prepare a samplesheet with your input data that looks as follows:
 
 ```csv
 sample,fastq_1,fastq_2
-CONTROL_REP1,AEG588A1_S1_L002_R1_001.fastq.gz,AEG588A1_S1_L002_R2_001.fastq.gz
+DENV1_sample,DENV1_S1_L001_R1_001.fastq.gz,DENV1_S1_L001_R2_001.fastq.gz
+DENV2_sample,DENV2_S2_L001_R1_001.fastq.gz,DENV2_S2_L001_R2_001.fastq.gz
 ```
 
-Each row represents a fastq file (single-end) or a pair of fastq files (paired end).
+Each row represents a paired-end sample for DENV analysis.
 
--->
+### Reference Assets
+
+Reference files (FASTA, BED) are managed externally. The default configuration expects assets in a sibling directory:
+
+```
+parent_directory/
+├── denver/              # This pipeline
+└── assets/
+    └── denver/
+        └── 1.0.0/
+            └── references/
+                ├── DENV1.fasta, DENV1.bed, ...
+                └── refs.txt
+```
+
+To use a custom references location:
+```bash
+nextflow run smagala/denver --references_base /path/to/references
+```
 
 Now, you can run the pipeline using:
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,18 @@ params {
     igenomes_base              = 's3://ngi-igenomes/igenomes/'
     igenomes_ignore            = false
 
+    // Denver-specific parameters
+    // Assets are managed externally - default path assumes sibling 'assets' directory
+    references_base            = "${projectDir}/../assets/denver/1.0.0/references"
+    serotypes_file             = "${params.references_base}/refs.txt"
+    min_depth                  = 10
+    consensus_threshold        = 0.75
+    variant_threshold          = 0.03
+    coverage_threshold         = 0.50
+    read_cap                   = 10000
+    skip_qc                    = false
+    ct_file                    = null
+
     // MultiQC options
     multiqc_config             = null
     multiqc_title              = null


### PR DESCRIPTION
## Summary
- Configure nextflow.config to use external assets directory
- Update README with pipeline description and workflow steps
- No large files in repository - assets managed externally

## Changes
- **nextflow.config**: Added Denver-specific parameters
  - `references_base` points to `../assets/denver/1.0.0/references`
  - Added `min_depth`, `consensus_threshold`, `variant_threshold`
  - Added `coverage_threshold`, `read_cap`, `skip_qc`, `ct_file`
- **README.md**: Updated with DENV analysis description and asset documentation

## Asset Structure (External)
```
parent_directory/
├── denver/              # This pipeline
└── assets/
    └── denver/
        └── 1.0.0/
            └── references/
                ├── DENV1.fasta, DENV1.bed, DENV1.trim.bed
                ├── DENV2.fasta, DENV2.bed, DENV2.trim.bed
                ├── ... (all serotypes)
                └── refs.txt
```

## Test Plan
- [ ] Verify config parses correctly with `nextflow config`
- [ ] Verify assets path resolves correctly

## Related Issues
Relates to #10, #11, #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)