### PR TITLE
[Epic 4] Subworkflow Implementation

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -26,6 +26,13 @@
                 "exists": true,
                 "pattern": "^([\\S\\s]*\\/)?[^\\s\\/]+\\.f(ast)?q\\.gz$",
                 "errorMessage": "FastQ file for reads 2 cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
+            },
+            "ct": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 50,
+                "errorMessage": "Ct value must be a number between 0 and 50",
+                "meta": ["ct"]
             }
         },
         "required": ["sample", "fastq_1"]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -46,6 +46,7 @@ process {
 
     withName: 'BWA_MEM' {
         ext.args = '-v 1 -O 10'  // Verbose level 1, gap open penalty 10
+        ext.args2 = '-bS -F 4 -F 2048'  // BAM output, exclude unmapped and supplementary
         publishDir = [
             path: { "${params.outdir}/alignment" },
             mode: params.publish_dir_mode,
@@ -55,15 +56,8 @@ process {
     }
 
     // Samtools BAM processing
-    withName: 'SAMTOOLS_VIEW' {
-        ext.args = '-F 4 -F 2048'  // Exclude unmapped and supplementary alignments
-    }
-
-    withName: 'SAMTOOLS_SORT' {
-        ext.prefix = { "${meta.id}.sorted" }
-    }
-
-    withName: 'SAMTOOLS_INDEX' {
+    withName: 'SAMTOOLS_SORT_ALIGN' {
+        ext.prefix = { "${meta.id}.aligned" }
         publishDir = [
             path: { "${params.outdir}/alignment" },
             mode: params.publish_dir_mode,
@@ -71,8 +65,22 @@ process {
         ]
     }
 
-    withName: 'SAMTOOLS_MPILEUP' {
-        ext.args = { "-aa -A -d ${params.read_cap} -Q 0" }  // All positions, all reads, depth cap
+    withName: 'SAMTOOLS_SORT_TRIM' {
+        ext.prefix = { "${meta.id}.sorted" }
+        publishDir = [
+            path: { "${params.outdir}/alignment" },
+            mode: params.publish_dir_mode,
+            pattern: '*.bam',
+            enabled: true  // Publish final sorted BAMs
+        ]
+    }
+
+    withName: 'SAMTOOLS_FAIDX' {
+        publishDir = [
+            path: { "${params.outdir}/reference" },
+            mode: params.publish_dir_mode,
+            enabled: false
+        ]
     }
 
     // iVar primer trimming and variant calling
@@ -88,7 +96,8 @@ process {
 
     withName: 'IVAR_CONSENSUS' {
         ext.args = { "-t ${params.consensus_threshold} -m ${params.min_depth}" }
-        ext.args2 = { "-i ${meta.id}" }  // Consensus sequence name
+        ext.args2 = { "-aa -A -d ${params.read_cap} -Q 0" }  // mpileup args
+        ext.prefix = { "${meta.id}.${meta.serotype}.${params.min_depth}.cons" }
         publishDir = [
             path: { "${params.outdir}/consensus" },
             mode: params.publish_dir_mode,
@@ -98,6 +107,8 @@ process {
 
     withName: 'IVAR_VARIANTS' {
         ext.args = { "-q 20 -t ${params.variant_threshold}" }
+        ext.args2 = { "-aa -A -d 0 -Q 0" }  // mpileup args (no depth cap for variants)
+        ext.prefix = { "${meta.id}.${meta.serotype}.${params.min_depth}.variants" }
         publishDir = [
             path: { "${params.outdir}/variants" },
             mode: params.publish_dir_mode,
@@ -108,6 +119,7 @@ process {
     // Depth profiling
     withName: 'BEDTOOLS_GENOMECOV' {
         ext.args = '-d'  // Report depth at each position
+        ext.prefix = { "${meta.id}.${meta.serotype}.depth" }
         publishDir = [
             path: { "${params.outdir}/coverage" },
             mode: params.publish_dir_mode,
@@ -115,21 +127,67 @@ process {
         ]
     }
 
-    // Sequence alignment (nextalign/nextclade primary, mafft fallback)
-    withName: 'NEXTCLADE_RUN' {
+    // Sequence alignment (nextclade primary, mafft fallback)
+    withName: 'NEXTCLADE_ALIGN' {
+        ext.prefix = { "${meta.id}.${meta.serotype}.${params.min_depth}.out" }
         publishDir = [
             path: { "${params.outdir}/alignment" },
             mode: params.publish_dir_mode,
-            pattern: '*.aln'
+            pattern: '*.aln.fasta'
         ]
     }
 
     withName: 'MAFFT_ALIGN' {
         ext.args = '--quiet --6merpair --keeplength'  // Fallback alignment settings
+        ext.prefix = { "${meta.id}.${meta.serotype}.${params.min_depth}.out" }
         publishDir = [
             path: { "${params.outdir}/alignment" },
             mode: params.publish_dir_mode,
-            pattern: '*.aln'
+            pattern: '*.fas'
+        ]
+    }
+
+    //
+    // Local modules configuration
+    //
+
+    withName: 'SEROTYPE_CALLER' {
+        publishDir = [
+            path: { "${params.outdir}/serotype_calls" },
+            mode: params.publish_dir_mode,
+            pattern: '*.tsv'
+        ]
+    }
+
+    withName: 'FILTER_VARIANTS' {
+        publishDir = [
+            path: { "${params.outdir}/variants" },
+            mode: params.publish_dir_mode,
+            pattern: '*_variants_frequency.tsv'
+        ]
+    }
+
+    withName: 'EMPTY_HANDLER' {
+        publishDir = [
+            path: { "${params.outdir}/serotype_calls" },
+            mode: params.publish_dir_mode,
+            enabled: false  // Don't publish placeholder files
+        ]
+    }
+
+    withName: 'SUMMARIZE_RESULTS' {
+        publishDir = [
+            path: { "${params.outdir}/results" },
+            mode: params.publish_dir_mode,
+            pattern: '*.{tsv,csv}'
+        ]
+    }
+
+    withName: 'QC_PLOTS' {
+        publishDir = [
+            path: { "${params.outdir}/results" },
+            mode: params.publish_dir_mode,
+            pattern: '*.pdf'
         ]
     }
 

--- a/modules.json
+++ b/modules.json
@@ -55,6 +55,11 @@
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
                         "installed_by": ["modules"]
                     },
+                    "samtools/faidx": {
+                        "branch": "master",
+                        "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
+                        "installed_by": ["modules"]
+                    },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",

--- a/modules/local/nextclade/align/main.nf
+++ b/modules/local/nextclade/align/main.nf
@@ -1,0 +1,43 @@
+process NEXTCLADE_ALIGN {
+    tag "${meta.id}"
+    label 'process_single'
+    container '025066257930.dkr.ecr.us-east-1.amazonaws.com/oamd-bio-nextclade:3.18.1-cli_f556ccb_20251220'
+
+    input:
+    tuple val(meta), path(consensus)
+    path(reference)
+
+    output:
+    tuple val(meta), path("*.aln.fasta"), emit: alignment
+    path("versions.yml")               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    nextclade run \\
+        ${args} \\
+        --input-ref ${reference} \\
+        --output-fasta ${prefix}.aln.fasta \\
+        ${consensus}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        nextclade: \$(nextclade --version 2>&1 | sed 's/^nextclade //')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.aln.fasta
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        nextclade: \$(nextclade --version 2>&1 | sed 's/^nextclade //')
+    END_VERSIONS
+    """
+}

--- a/modules/local/nextclade/align/meta.yml
+++ b/modules/local/nextclade/align/meta.yml
@@ -1,0 +1,49 @@
+name: "nextclade_align"
+description: Perform pairwise alignment of consensus sequence against reference using Nextclade
+keywords:
+  - alignment
+  - consensus
+  - nextclade
+  - pairwise
+tools:
+  - "nextclade":
+      description: "Viral genome sequence alignment and analysis"
+      homepage: "https://github.com/nextstrain/nextclade"
+      documentation: "https://docs.nextstrain.org/projects/nextclade/en/stable/"
+      licence: ["MIT"]
+      identifier: "biotools:nextclade"
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', serotype:'DENV1' ]`
+    - consensus:
+        type: file
+        description: Consensus FASTA file to align
+        pattern: "*.{fa,fasta}"
+  - - reference:
+        type: file
+        description: Reference FASTA file
+        pattern: "*.{fa,fasta}"
+
+output:
+  - alignment:
+      - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.aln.fasta":
+          type: file
+          description: Aligned FASTA file
+          pattern: "*.aln.fasta"
+  - versions:
+      - "versions.yml":
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+
+authors:
+  - "@smagala"
+maintainers:
+  - "@smagala"

--- a/modules/local/qc_plots/main.nf
+++ b/modules/local/qc_plots/main.nf
@@ -7,9 +7,7 @@ process QC_PLOTS {
     input:
     path(serotype_calls)
     path(variants_summary)
-    path(ct_file)
-    val(ct_column)
-    val(id_column)
+    path(ct_data)  // TSV with sample_id and ct columns, or empty file
 
     output:
     path("variant_plot.pdf"), emit: variant_plot

--- a/modules/local/qc_plots/templates/qc_plots.py
+++ b/modules/local/qc_plots/templates/qc_plots.py
@@ -90,26 +90,26 @@ def create_variant_plot(variants_file, virus_dict, colour_dict, patch_list):
     plt.close()
 
 
-def create_ct_plot(ct_file, ct_column, id_column, serotype_file, virus_dict, colour_dict, patch_list):
+def create_ct_plot(ct_file, serotype_file, virus_dict, colour_dict, patch_list):
     """Create scatter plot of Ct values vs coverage."""
-    if not os.path.exists(ct_file) or ct_file == "NO_FILE":
+    # Check if ct_data file exists and has content
+    if not os.path.exists(ct_file) or os.path.getsize(ct_file) == 0:
         return False
 
-    # Load Ct values
+    # Load Ct values from the pre-formatted TSV
     ct_dict = {}
     with open(ct_file) as f:
-        reader = csv.DictReader(f)
+        reader = csv.DictReader(f, delimiter="\\t")
         for row in reader:
-            sample_id = row.get(id_column, "")
-            if sample_id not in virus_dict:
-                continue
-            try:
-                value = float(row.get(ct_column, 45))
-                if np.isnan(value):
-                    value = 45
-            except (ValueError, TypeError):
-                value = 45
-            ct_dict[sample_id] = value
+            sample_id = row.get("sample_id", "")
+            ct_value = row.get("ct", "")
+            if sample_id and ct_value and sample_id in virus_dict:
+                try:
+                    value = float(ct_value)
+                    if not np.isnan(value):
+                        ct_dict[sample_id] = value
+                except (ValueError, TypeError):
+                    pass
 
     if not ct_dict:
         return False
@@ -159,9 +159,7 @@ if __name__ == "__main__":
     # Nextflow variable substitution
     serotype_file = "${serotype_calls}"
     variants_file = "${variants_summary}"
-    ct_file = "${ct_file}"
-    ct_column = "${ct_column}"
-    id_column = "${id_column}"
+    ct_file = "${ct_data}"
 
     # Load serotype data and create color mapping
     virus_dict, colour_dict, patch_list = load_serotype_data(serotype_file)
@@ -171,9 +169,7 @@ if __name__ == "__main__":
         create_variant_plot(variants_file, virus_dict, colour_dict, patch_list)
 
         # Create Ct plot if data available
-        create_ct_plot(
-            ct_file, ct_column, id_column, serotype_file, virus_dict, colour_dict, patch_list
-        )
+        create_ct_plot(ct_file, serotype_file, virus_dict, colour_dict, patch_list)
 
     # Version reporting
     import matplotlib

--- a/modules/nf-core/samtools/faidx/environment.yml
+++ b/modules/nf-core/samtools/faidx/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/htslib
+  - bioconda::htslib=1.22.1
+  # renovate: datasource=conda depName=bioconda/samtools
+  - bioconda::samtools=1.22.1

--- a/modules/nf-core/samtools/faidx/main.nf
+++ b/modules/nf-core/samtools/faidx/main.nf
@@ -1,0 +1,61 @@
+process SAMTOOLS_FAIDX {
+    tag "$fasta"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samtools:1.22.1--h96c455f_0' :
+        'biocontainers/samtools:1.22.1--h96c455f_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+    tuple val(meta2), path(fai)
+    val get_sizes
+
+    output:
+    tuple val(meta), path ("*.{fa,fasta}") , emit: fa, optional: true
+    tuple val(meta), path ("*.sizes")      , emit: sizes, optional: true
+    tuple val(meta), path ("*.fai")        , emit: fai, optional: true
+    tuple val(meta), path ("*.gzi")        , emit: gzi, optional: true
+    path "versions.yml"                    , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def get_sizes_command = get_sizes ? "cut -f 1,2 ${fasta}.fai > ${fasta}.sizes" : ''
+    """
+    samtools \\
+        faidx \\
+        $fasta \\
+        $args
+
+    ${get_sizes_command}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def match = (task.ext.args =~ /-o(?:utput)?\s(.*)\s?/).findAll()
+    def fastacmd = match[0] ? "touch ${match[0][1]}" : ''
+    def get_sizes_command = get_sizes ? "touch ${fasta}.sizes" : ''
+    """
+    ${fastacmd}
+    touch ${fasta}.fai
+    if [[ "${fasta.extension}" == "gz" ]]; then
+        touch ${fasta}.gzi
+    fi
+
+    ${get_sizes_command}
+
+    cat <<-END_VERSIONS > versions.yml
+
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/samtools/faidx/meta.yml
+++ b/modules/nf-core/samtools/faidx/meta.yml
@@ -1,0 +1,102 @@
+name: samtools_faidx
+description: Index FASTA file, and optionally generate a file of chromosome sizes
+keywords:
+  - index
+  - fasta
+  - faidx
+  - chromosome
+tools:
+  - samtools:
+      description: |
+        SAMtools is a set of utilities for interacting with and post-processing
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+        These files are generated as output by short read aligners like BWA.
+      homepage: http://www.htslib.org/
+      documentation: http://www.htslib.org/doc/samtools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
+      identifier: biotools:samtools
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'test' ]
+    - fasta:
+        type: file
+        description: FASTA file
+        pattern: "*.{fa,fasta}"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'test' ]
+    - fai:
+        type: file
+        description: FASTA index file
+        pattern: "*.{fai}"
+        ontologies: []
+  - get_sizes:
+      type: boolean
+      description: use cut to get the sizes of the index (true) or not (false)
+
+output:
+  fa:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.{fa,fasta}":
+          type: file
+          description: FASTA file
+          pattern: "*.{fa}"
+          ontologies: []
+  sizes:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.sizes":
+          type: file
+          description: File containing chromosome lengths
+          pattern: "*.{sizes}"
+          ontologies: []
+  fai:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fai":
+          type: file
+          description: FASTA index file
+          pattern: "*.{fai}"
+          ontologies: []
+  gzi:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.gzi":
+          type: file
+          description: Optional gzip index file for compressed inputs
+          pattern: "*.gzi"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@drpatelh"
+  - "@ewels"
+  - "@phue"
+maintainers:
+  - "@maxulysse"
+  - "@phue"

--- a/modules/nf-core/samtools/faidx/tests/main.nf.test
+++ b/modules/nf-core/samtools/faidx/tests/main.nf.test
@@ -1,0 +1,219 @@
+nextflow_process {
+
+    name "Test Process SAMTOOLS_FAIDX"
+    script "../main.nf"
+    process "SAMTOOLS_FAIDX"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "samtools"
+    tag "samtools/faidx"
+
+    test("test_samtools_faidx") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
+                input[1] = [[],[]]
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_samtools_faidx_bgzip") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)]
+                input[1] = [[],[]]
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_samtools_faidx_fasta") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
+                input[1] = [ [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true) ]
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_samtools_faidx_stub_fasta") {
+
+        config "./nextflow2.config"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
+                input[1] = [ [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true) ]
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_samtools_faidx_stub_fai") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
+                input[1] = [[],[]]
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_samtools_faidx_get_sizes") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[1] = [[],[]]
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_samtools_faidx_get_sizes_bgzip") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ])
+                input[1] = [[],[]]
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_samtools_faidx_get_sizes - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[1] = [[],[]]
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_samtools_faidx_get_sizes_bgzip - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ])
+                input[1] = [[],[]]
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/samtools/faidx/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/faidx/tests/main.nf.test.snap
@@ -1,0 +1,543 @@
+{
+    "test_samtools_faidx": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.fasta.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ],
+                "fa": [
+                    
+                ],
+                "fai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.fasta.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "gzi": [
+                    
+                ],
+                "sizes": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T13:09:38.874686"
+    },
+    "test_samtools_faidx_get_sizes_bgzip - stub": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.gzi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,8e7d141eb8c2944042dfb5e942bffe08"
+                ],
+                "fa": [
+                    
+                ],
+                "fai": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "gzi": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.gzi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "sizes": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,8e7d141eb8c2944042dfb5e942bffe08"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T13:10:10.958397"
+    },
+    "test_samtools_faidx_get_sizes": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.sizes:md5,a57c401f27ae5133823fb09fb21c8a3c"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ],
+                "fa": [
+                    
+                ],
+                "fai": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "gzi": [
+                    
+                ],
+                "sizes": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.sizes:md5,a57c401f27ae5133823fb09fb21c8a3c"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T13:09:59.237249"
+    },
+    "test_samtools_faidx_bgzip": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.fasta.gz.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.fasta.gz.gzi:md5,7dea362b3fac8e00956a4952a3d4f474"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ],
+                "fa": [
+                    
+                ],
+                "fai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.fasta.gz.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "gzi": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.fasta.gz.gzi:md5,7dea362b3fac8e00956a4952a3d4f474"
+                    ]
+                ],
+                "sizes": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T13:09:42.949204"
+    },
+    "test_samtools_faidx_fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "extract.fa:md5,6a0774a0ad937ba0bfd2ac7457d90f36"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ],
+                "fa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "extract.fa:md5,6a0774a0ad937ba0bfd2ac7457d90f36"
+                    ]
+                ],
+                "fai": [
+                    
+                ],
+                "gzi": [
+                    
+                ],
+                "sizes": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T13:09:46.914038"
+    },
+    "test_samtools_faidx_get_sizes - stub": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    "versions.yml:md5,8e7d141eb8c2944042dfb5e942bffe08"
+                ],
+                "fa": [
+                    
+                ],
+                "fai": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "gzi": [
+                    
+                ],
+                "sizes": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,8e7d141eb8c2944042dfb5e942bffe08"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T13:10:06.961912"
+    },
+    "test_samtools_faidx_stub_fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "extract.fa:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ],
+                "fa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "extract.fa:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "fai": [
+                    
+                ],
+                "gzi": [
+                    
+                ],
+                "sizes": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T13:09:51.226016"
+    },
+    "test_samtools_faidx_stub_fai": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.fasta.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ],
+                "fa": [
+                    
+                ],
+                "fai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.fasta.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "gzi": [
+                    
+                ],
+                "sizes": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T13:09:55.423005"
+    },
+    "test_samtools_faidx_get_sizes_bgzip": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.sizes:md5,a57c401f27ae5133823fb09fb21c8a3c"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.gzi:md5,7dea362b3fac8e00956a4952a3d4f474"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ],
+                "fa": [
+                    
+                ],
+                "fai": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "gzi": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.gzi:md5,7dea362b3fac8e00956a4952a3d4f474"
+                    ]
+                ],
+                "sizes": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.sizes:md5,a57c401f27ae5133823fb09fb21c8a3c"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,001211003daf11e8dd2f1aca7a378a68"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T13:10:03.04872"
+    }
+}

--- a/modules/nf-core/samtools/faidx/tests/nextflow.config
+++ b/modules/nf-core/samtools/faidx/tests/nextflow.config
@@ -1,0 +1,7 @@
+process {
+
+    withName: SAMTOOLS_FAIDX {
+        ext.args = 'MT192765.1 -o extract.fa'
+    }
+
+}

--- a/modules/nf-core/samtools/faidx/tests/nextflow2.config
+++ b/modules/nf-core/samtools/faidx/tests/nextflow2.config
@@ -1,0 +1,6 @@
+process {
+
+    withName: SAMTOOLS_FAIDX {
+        ext.args = '-o extract.fa'
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,7 @@ params {
 
     // Denver-specific parameters
     // Assets are managed externally - default path assumes sibling 'assets' directory
-    references_base            = "${projectDir}/../assets/denver/1.0.0/references"
+    references_base            = "${projectDir}/../assets/denver/1.0.0"
     serotypes_file             = "${params.references_base}/refs.txt"
     min_depth                  = 10
     consensus_threshold        = 0.75

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,8 @@ params {
     read_cap                   = 10000
     skip_qc                    = false
     ct_file                    = null
+    ct_column                  = null
+    id_column                  = null
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,9 +30,6 @@ params {
     isnv_max_freq              = 0.80
     read_cap                   = 10000
     skip_qc                    = false
-    ct_file                    = null
-    ct_column                  = null
-    id_column                  = null
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -167,25 +167,6 @@
                     "description": "Skip QC visualization steps.",
                     "help_text": "Set to true to skip variant plots and coverage summaries.",
                     "fa_icon": "fas fa-forward"
-                },
-                "ct_file": {
-                    "type": "string",
-                    "format": "file-path",
-                    "description": "Optional file with Ct values for samples.",
-                    "help_text": "CSV file mapping sample IDs to Ct values for correlation analysis.",
-                    "fa_icon": "fas fa-file-csv"
-                },
-                "ct_column": {
-                    "type": "string",
-                    "description": "Name of column containing Ct values in ct_file.",
-                    "help_text": "Column header for Ct values. Defaults to 'Ct' if not specified.",
-                    "fa_icon": "fas fa-columns"
-                },
-                "id_column": {
-                    "type": "string",
-                    "description": "Name of column containing sample IDs in ct_file.",
-                    "help_text": "Column header for sample identifiers. Defaults to 'sample_id' if not specified.",
-                    "fa_icon": "fas fa-columns"
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -174,6 +174,18 @@
                     "description": "Optional file with Ct values for samples.",
                     "help_text": "CSV file mapping sample IDs to Ct values for correlation analysis.",
                     "fa_icon": "fas fa-file-csv"
+                },
+                "ct_column": {
+                    "type": "string",
+                    "description": "Name of column containing Ct values in ct_file.",
+                    "help_text": "Column header for Ct values. Defaults to 'Ct' if not specified.",
+                    "fa_icon": "fas fa-columns"
+                },
+                "id_column": {
+                    "type": "string",
+                    "description": "Name of column containing sample IDs in ct_file.",
+                    "help_text": "Column header for sample identifiers. Defaults to 'sample_id' if not specified.",
+                    "fa_icon": "fas fa-columns"
                 }
             }
         },

--- a/subworkflows/local/denv_serotype_analysis/main.nf
+++ b/subworkflows/local/denv_serotype_analysis/main.nf
@@ -1,0 +1,263 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    DENV SEROTYPE ANALYSIS SUBWORKFLOW
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Per-sample, per-serotype processing: alignment through variant calling.
+    This is the core processing chain that runs for each sample×serotype combination.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+include { BWA_MEM                              } from '../../../modules/nf-core/bwa/mem/main'
+include { SAMTOOLS_SORT as SAMTOOLS_SORT_ALIGN } from '../../../modules/nf-core/samtools/sort/main'
+include { SAMTOOLS_SORT as SAMTOOLS_SORT_TRIM  } from '../../../modules/nf-core/samtools/sort/main'
+include { SAMTOOLS_FAIDX                       } from '../../../modules/nf-core/samtools/faidx/main'
+include { IVAR_TRIM                            } from '../../../modules/nf-core/ivar/trim/main'
+include { IVAR_CONSENSUS                       } from '../../../modules/nf-core/ivar/consensus/main'
+include { IVAR_VARIANTS                        } from '../../../modules/nf-core/ivar/variants/main'
+include { BEDTOOLS_GENOMECOV                   } from '../../../modules/nf-core/bedtools/genomecov/main'
+include { MAFFT_ALIGN                          } from '../../../modules/nf-core/mafft/align/main'
+include { NEXTCLADE_ALIGN                      } from '../../../modules/local/nextclade/align/main'
+include { SEROTYPE_CALLER                      } from '../../../modules/local/serotype_caller/main'
+include { FILTER_VARIANTS                      } from '../../../modules/local/filter_variants/main'
+include { EMPTY_HANDLER                        } from '../../../modules/local/empty_handler/main'
+
+workflow DENV_SEROTYPE_ANALYSIS {
+
+    take:
+    ch_reads           // channel: [ val(meta), [ path(reads) ] ]
+    ch_bwa_index       // channel: [ val(meta_ref), path(index) ]
+    ch_reference       // channel: [ val(meta_ref), path(fasta) ]
+    ch_primer_bed      // channel: path(bed)
+    ch_trim_bed        // channel: path(bed) or "NO_FILE"
+    min_depth          // val: minimum depth for consensus
+    consensus_threshold // val: frequency threshold for consensus
+    variant_threshold  // val: frequency threshold for variants
+    coverage_threshold // val: coverage threshold for serotype call
+    isnv_min_freq      // val: min frequency for iSNV
+    isnv_max_freq      // val: max frequency for iSNV
+    read_cap           // val: max depth for mpileup
+
+    main:
+    ch_versions = Channel.empty()
+
+    //
+    // MODULE: Index reference FASTA (needed for IVAR_VARIANTS)
+    //
+    SAMTOOLS_FAIDX (
+        ch_reference,
+        [[:], []],  // existing fai (none)
+        false       // don't create sizes file
+    )
+    ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions.first())
+
+    //
+    // MODULE: Align reads with BWA MEM
+    // sort_bam=false allows filtering via args2, then sort separately
+    //
+    BWA_MEM (
+        ch_reads,
+        ch_bwa_index,
+        ch_reference,
+        false  // sort_bam = false
+    )
+    ch_versions = ch_versions.mix(BWA_MEM.out.versions.first())
+
+    //
+    // MODULE: Sort aligned BAM and create index
+    //
+    SAMTOOLS_SORT_ALIGN (
+        BWA_MEM.out.bam,
+        ch_reference,
+        "bai"  // create BAI index
+    )
+
+    //
+    // Combine BAM with BAI for IVAR_TRIM
+    //
+    SAMTOOLS_SORT_ALIGN.out.bam
+        .join(SAMTOOLS_SORT_ALIGN.out.bai)
+        .set { ch_sorted_bam_bai }
+
+    //
+    // MODULE: Trim primers with ivar
+    //
+    IVAR_TRIM (
+        ch_sorted_bam_bai,
+        ch_primer_bed
+    )
+    ch_versions = ch_versions.mix(IVAR_TRIM.out.versions.first())
+
+    //
+    // Branch: Check if trimmed BAM has reads
+    // BAM header is ~few hundred bytes, empty BAM is small
+    //
+    IVAR_TRIM.out.bam
+        .branch { meta, bam ->
+            has_reads: bam.size() > 1000
+            empty: true
+        }
+        .set { ch_trimmed_branch }
+
+    //
+    // MODULE: Handle empty samples (no reads after trimming)
+    //
+    ch_trimmed_branch.empty
+        .map { meta, bam ->
+            def serotype = meta.serotype ?: "UNKNOWN"
+            [ meta, serotype ]
+        }
+        .set { ch_empty_samples }
+
+    EMPTY_HANDLER (
+        ch_empty_samples.map { meta, serotype -> meta },
+        min_depth,
+        ch_empty_samples.map { meta, serotype -> serotype }
+    )
+    ch_versions = ch_versions.mix(EMPTY_HANDLER.out.versions.first().ifEmpty([]))
+
+    //
+    // Continue processing for samples with reads
+    //
+
+    //
+    // MODULE: Sort trimmed BAM
+    //
+    SAMTOOLS_SORT_TRIM (
+        ch_trimmed_branch.has_reads,
+        ch_reference,
+        "bai"
+    )
+
+    //
+    // Prepare indexed BAM for downstream processes
+    //
+    SAMTOOLS_SORT_TRIM.out.bam
+        .join(SAMTOOLS_SORT_TRIM.out.bai)
+        .map { meta, bam, bai -> [ meta, bam ] }
+        .set { ch_indexed_bam }
+
+    //
+    // MODULE: Generate consensus sequence
+    // IVAR_CONSENSUS runs mpileup internally
+    //
+    IVAR_CONSENSUS (
+        ch_indexed_bam,
+        ch_reference.map { meta, fasta -> fasta },
+        false  // save_mpileup
+    )
+    ch_versions = ch_versions.mix(IVAR_CONSENSUS.out.versions.first())
+
+    //
+    // MODULE: Align consensus to reference
+    //
+    NEXTCLADE_ALIGN (
+        IVAR_CONSENSUS.out.fasta,
+        ch_reference.map { meta, fasta -> fasta }
+    )
+    ch_versions = ch_versions.mix(NEXTCLADE_ALIGN.out.versions.first())
+
+    //
+    // Check for empty alignment (nextalign failure)
+    // If empty, fall back to MAFFT
+    //
+    NEXTCLADE_ALIGN.out.alignment
+        .branch { meta, aln ->
+            has_alignment: aln.size() > 0
+            empty: true
+        }
+        .set { ch_alignment_branch }
+
+    //
+    // MODULE: MAFFT fallback for failed nextalign
+    // Original uses: mafft --quiet --6merpair --keeplength --addfragments consensus reference
+    //
+    ch_alignment_branch.empty
+        .join(IVAR_CONSENSUS.out.fasta)
+        .map { meta, empty_aln, consensus -> [ meta, consensus ] }
+        .set { ch_for_mafft }
+
+    // Prepare inputs for MAFFT: reference as main fasta, consensus as addfragments
+    MAFFT_ALIGN (
+        ch_reference,              // fasta (reference)
+        [[:], []],                 // add
+        ch_for_mafft,              // addfragments (consensus)
+        [[:], []],                 // addfull
+        [[:], []],                 // addprofile
+        [[:], []],                 // addlong
+        false                      // compress
+    )
+    ch_versions = ch_versions.mix(MAFFT_ALIGN.out.versions.first().ifEmpty([]))
+
+    //
+    // Combine alignment outputs
+    //
+    ch_alignment_branch.has_alignment
+        .mix(MAFFT_ALIGN.out.fas)
+        .set { ch_alignments }
+
+    //
+    // MODULE: Calculate coverage and call serotype
+    //
+    SEROTYPE_CALLER (
+        ch_alignments,
+        ch_trim_bed,
+        coverage_threshold
+    )
+    ch_versions = ch_versions.mix(SEROTYPE_CALLER.out.versions.first())
+
+    //
+    // MODULE: Call variants
+    // IVAR_VARIANTS runs mpileup internally with different params
+    //
+    IVAR_VARIANTS (
+        ch_indexed_bam,
+        ch_reference.map { meta, fasta -> fasta },
+        SAMTOOLS_FAIDX.out.fai.map { meta, fai -> fai },
+        [],    // No GFF
+        false  // save_mpileup
+    )
+    ch_versions = ch_versions.mix(IVAR_VARIANTS.out.versions.first())
+
+    //
+    // MODULE: Filter variants for iSNV
+    //
+    FILTER_VARIANTS (
+        IVAR_VARIANTS.out.tsv,
+        isnv_min_freq,
+        isnv_max_freq
+    )
+    ch_versions = ch_versions.mix(FILTER_VARIANTS.out.versions.first())
+
+    //
+    // MODULE: Calculate depth coverage
+    //
+    ch_indexed_bam
+        .map { meta, bam -> [ meta, bam, 1 ] }  // scale = 1
+        .set { ch_for_genomecov }
+
+    BEDTOOLS_GENOMECOV (
+        ch_for_genomecov,
+        [],    // no sizes file (using BAM)
+        "txt", // output extension
+        false  // don't sort
+    )
+    ch_versions = ch_versions.mix(BEDTOOLS_GENOMECOV.out.versions.first())
+
+    //
+    // Combine outputs from both branches (has_reads + empty)
+    //
+    ch_serotype_call = SEROTYPE_CALLER.out.serotype_call
+        .mix(EMPTY_HANDLER.out.virustype_info)
+
+    ch_variants = FILTER_VARIANTS.out.variants
+        .mix(EMPTY_HANDLER.out.variants)
+
+    emit:
+    consensus      = IVAR_CONSENSUS.out.fasta       // channel: [ val(meta), path(fasta) ]
+    alignment      = ch_alignments                   // channel: [ val(meta), path(aln) ]
+    serotype_call  = ch_serotype_call               // channel: [ val(meta), path(tsv) ]
+    variants       = ch_variants                    // channel: [ val(meta), path(tsv) ]
+    depth          = BEDTOOLS_GENOMECOV.out.genomecov // channel: [ val(meta), path(txt) ]
+    bam            = ch_indexed_bam                 // channel: [ val(meta), path(bam) ]
+    versions       = ch_versions                    // channel: [ path(versions.yml) ]
+}

--- a/workflows/denver.nf
+++ b/workflows/denver.nf
@@ -3,12 +3,17 @@
     IMPORT MODULES / SUBWORKFLOWS / FUNCTIONS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-include { FASTQC                 } from '../modules/nf-core/fastqc/main'
-include { MULTIQC                } from '../modules/nf-core/multiqc/main'
-include { paramsSummaryMap       } from 'plugin/nf-schema'
-include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_denver_pipeline'
+
+include { FASTQC                      } from '../modules/nf-core/fastqc/main'
+include { MULTIQC                     } from '../modules/nf-core/multiqc/main'
+include { BWA_INDEX                   } from '../modules/nf-core/bwa/index/main'
+include { SUMMARIZE_RESULTS           } from '../modules/local/summarize_results/main'
+include { QC_PLOTS                    } from '../modules/local/qc_plots/main'
+include { DENV_SEROTYPE_ANALYSIS      } from '../subworkflows/local/denv_serotype_analysis/main'
+include { paramsSummaryMap            } from 'plugin/nf-schema'
+include { paramsSummaryMultiqc        } from '../subworkflows/nf-core/utils_nfcore_pipeline'
+include { softwareVersionsToYAML      } from '../subworkflows/nf-core/utils_nfcore_pipeline'
+include { methodsDescriptionText      } from '../subworkflows/local/utils_nfcore_denver_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -20,10 +25,12 @@ workflow DENVER {
 
     take:
     ch_samplesheet // channel: samplesheet read in from --input
+
     main:
 
-    ch_versions = channel.empty()
-    ch_multiqc_files = channel.empty()
+    ch_versions = Channel.empty()
+    ch_multiqc_files = Channel.empty()
+
     //
     // MODULE: Run FastQC
     //
@@ -31,7 +38,172 @@ workflow DENVER {
         ch_samplesheet
     )
     ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]})
-    // Note: FASTQC versions now emitted via topic:versions (captured by Channel.topic below)
+
+    //
+    // Load serotype references from refs.txt
+    //
+    Channel
+        .fromPath(params.serotypes_file)
+        .splitText()
+        .map { it.trim() }
+        .filter { it }  // Remove empty lines
+        .set { ch_serotypes }
+
+    //
+    // Create channels for each serotype's reference files
+    //
+    ch_serotypes
+        .map { serotype ->
+            def fasta = file("${params.references_base}/${serotype}.fasta", checkIfExists: true)
+            def bed = file("${params.references_base}/${serotype}.bed", checkIfExists: true)
+            def trim_bed = file("${params.references_base}/${serotype}.trim.bed")
+            def trim_bed_path = trim_bed.exists() ? trim_bed : file("NO_FILE")
+            [
+                [ id: serotype ],  // meta for reference
+                fasta,
+                bed,
+                trim_bed_path
+            ]
+        }
+        .set { ch_references }
+
+    //
+    // MODULE: Create BWA index for each serotype reference
+    //
+    ch_references
+        .map { meta, fasta, bed, trim_bed -> [ meta, fasta ] }
+        .set { ch_fasta_for_index }
+
+    BWA_INDEX (
+        ch_fasta_for_index
+    )
+    ch_versions = ch_versions.mix(BWA_INDEX.out.versions.first())
+
+    //
+    // Prepare reference channels with index
+    //
+    BWA_INDEX.out.index
+        .join(ch_references.map { meta, fasta, bed, trim_bed -> [ meta, fasta, bed, trim_bed ] })
+        .map { meta, index, fasta, bed, trim_bed ->
+            [ meta, index, fasta, bed, trim_bed ]
+        }
+        .set { ch_indexed_references }
+
+    //
+    // Cross samples with serotypes to create all combinations
+    //
+    ch_samplesheet
+        .combine(ch_indexed_references)
+        .map { sample_meta, reads, ref_meta, index, fasta, bed, trim_bed ->
+            def new_meta = sample_meta + [ serotype: ref_meta.id ]
+            [
+                new_meta,    // sample meta with serotype
+                reads,       // sample reads
+                ref_meta,    // reference meta
+                index,       // bwa index
+                fasta,       // reference fasta
+                bed,         // primer bed
+                trim_bed     // trim bed (optional)
+            ]
+        }
+        .set { ch_sample_serotype_combinations }
+
+    //
+    // Prepare channels for subworkflow inputs
+    //
+    ch_sample_serotype_combinations
+        .map { meta, reads, ref_meta, index, fasta, bed, trim_bed ->
+            [ meta, reads ]
+        }
+        .set { ch_reads }
+
+    ch_sample_serotype_combinations
+        .map { meta, reads, ref_meta, index, fasta, bed, trim_bed ->
+            [ ref_meta, index ]
+        }
+        .unique()
+        .set { ch_bwa_index }
+
+    ch_sample_serotype_combinations
+        .map { meta, reads, ref_meta, index, fasta, bed, trim_bed ->
+            [ ref_meta, fasta ]
+        }
+        .unique()
+        .set { ch_reference_fasta }
+
+    ch_sample_serotype_combinations
+        .map { meta, reads, ref_meta, index, fasta, bed, trim_bed ->
+            bed
+        }
+        .first()
+        .set { ch_primer_bed }
+
+    ch_sample_serotype_combinations
+        .map { meta, reads, ref_meta, index, fasta, bed, trim_bed ->
+            trim_bed
+        }
+        .first()
+        .set { ch_trim_bed }
+
+    //
+    // SUBWORKFLOW: Run DENV serotype analysis for each sample×serotype
+    //
+    DENV_SEROTYPE_ANALYSIS (
+        ch_reads,
+        ch_bwa_index,
+        ch_reference_fasta,
+        ch_primer_bed,
+        ch_trim_bed,
+        params.min_depth,
+        params.consensus_threshold,
+        params.variant_threshold,
+        params.coverage_threshold,
+        params.isnv_min_freq,
+        params.isnv_max_freq,
+        params.read_cap
+    )
+    ch_versions = ch_versions.mix(DENV_SEROTYPE_ANALYSIS.out.versions)
+
+    //
+    // Collect all serotype calls for summarization
+    //
+    DENV_SEROTYPE_ANALYSIS.out.serotype_call
+        .map { meta, tsv -> tsv }
+        .collect()
+        .set { ch_all_serotype_calls }
+
+    DENV_SEROTYPE_ANALYSIS.out.variants
+        .map { meta, tsv -> tsv }
+        .collect()
+        .set { ch_all_variants }
+
+    //
+    // MODULE: Summarize results across all samples
+    //
+    SUMMARIZE_RESULTS (
+        ch_all_serotype_calls,
+        ch_all_variants,
+        params.coverage_threshold
+    )
+    ch_versions = ch_versions.mix(SUMMARIZE_RESULTS.out.versions)
+
+    //
+    // MODULE: Generate QC plots (optional)
+    //
+    if (!params.skip_qc) {
+        def ct_file = params.ct_file ? file(params.ct_file) : file("NO_FILE")
+        def ct_column = params.ct_column ?: "Ct"
+        def id_column = params.id_column ?: "sample_id"
+
+        QC_PLOTS (
+            SUMMARIZE_RESULTS.out.serotype_calls,
+            SUMMARIZE_RESULTS.out.variants_summary,
+            ct_file,
+            ct_column,
+            id_column
+        )
+        ch_versions = ch_versions.mix(QC_PLOTS.out.versions)
+    }
 
     //
     // Collate and save software versions
@@ -61,7 +233,6 @@ workflow DENVER {
             sort: true,
             newLine: true
         ).set { ch_collated_versions }
-
 
     //
     // MODULE: MultiQC
@@ -103,9 +274,9 @@ workflow DENVER {
         []
     )
 
-    emit:multiqc_report = MULTIQC.out.report.toList() // channel: /path/to/multiqc_report.html
-    versions       = ch_versions                 // channel: [ path(versions.yml) ]
-
+    emit:
+    multiqc_report = MULTIQC.out.report.toList()
+    versions       = ch_versions
 }
 
 /*

--- a/workflows/denver.nf
+++ b/workflows/denver.nf
@@ -191,16 +191,23 @@ workflow DENVER {
     // MODULE: Generate QC plots (optional)
     //
     if (!params.skip_qc) {
-        def ct_file = params.ct_file ? file(params.ct_file) : file("NO_FILE")
-        def ct_column = params.ct_column ?: "Ct"
-        def id_column = params.id_column ?: "sample_id"
+        // Extract Ct data from samplesheet meta and create TSV
+        ch_samplesheet
+            .filter { meta, reads -> meta.ct != null }
+            .map { meta, reads -> "${meta.id}\t${meta.ct}" }
+            .collect()
+            .map { lines ->
+                def content = "sample_id\tct\n" + lines.join("\n")
+                content
+            }
+            .collectFile(name: 'ct_data.tsv', newLine: false, storeDir: "${params.outdir}/pipeline_info")
+            .ifEmpty { file("NO_FILE") }
+            .set { ch_ct_data }
 
         QC_PLOTS (
             SUMMARIZE_RESULTS.out.serotype_calls,
             SUMMARIZE_RESULTS.out.variants_summary,
-            ct_file,
-            ct_column,
-            id_column
+            ch_ct_data
         )
         ch_versions = ch_versions.mix(QC_PLOTS.out.versions)
     }


### PR DESCRIPTION
## Summary
- Implement DENV_SEROTYPE_ANALYSIS subworkflow for per-sample-per-serotype processing
- Create local nextclade/align module for consensus-to-reference alignment
- Wire main workflow to orchestrate complete pipeline flow
- Configure all process arguments and publishDir settings

## Architecture
Following guidance to avoid over-nesting:

**Single subworkflow (DENV_SEROTYPE_ANALYSIS):**
- BWA_MEM → SAMTOOLS_SORT → IVAR_TRIM → empty check
- SAMTOOLS_SORT → IVAR_CONSENSUS → NEXTCLADE_ALIGN (MAFFT fallback)
- SEROTYPE_CALLER → IVAR_VARIANTS → FILTER_VARIANTS → BEDTOOLS_GENOMECOV

**Standalone in main workflow:**
- FASTQC (QC)
- BWA_INDEX (per serotype reference)
- SUMMARIZE_RESULTS (aggregation)
- QC_PLOTS (optional visualization)
- MULTIQC (reporting)

## Changes
- `subworkflows/local/denv_serotype_analysis/main.nf` - Core processing subworkflow
- `modules/local/nextclade/align/` - Local module for nextclade alignment
- `modules/nf-core/samtools/faidx/` - Installed for reference indexing
- `conf/modules.config` - Process configuration (args, publishDir)
- `workflows/denver.nf` - Main workflow orchestration
- `nextflow.config` - Added ct_column, id_column params
- `nextflow_schema.json` - Schema updates for new params

## Test plan
- [ ] Verify nextflow config parses without errors
- [ ] Run nf-core lint
- [ ] Test with sample data when available
- [ ] Verify output directory structure matches expected

## Closes
- #39 (Story 1: DENV_SEROTYPE_ANALYSIS subworkflow)
- #40 (Story 2: Main workflow orchestration)
- #41 (Story 3: modules.config configuration)
- #42 (Story 4: nextclade alignment module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)