### PR TITLE
[Epic 6] Complete documentation for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,46 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.0dev - [date]
+## v1.0.0 - 2025-12-21
 
-Initial release of smagala/denver, created with the [nf-core](https://nf-co.re/) template.
+Initial release of smagala/denver, a Dengue virus (DENV) analysis pipeline built with the [nf-core](https://nf-co.re/) template.
 
 ### `Added`
 
-### `Fixed`
+- Multi-serotype analysis against DENV1-4 and sylvatic variants (DENV2_sylvatic, DENV4_sylvatic)
+- Read quality control using Falco (FastQC-compatible, 3x faster)
+- BWA-MEM alignment to serotype-specific reference genomes
+- iVar primer trimming with amplicon-specific BED files
+- iVar consensus sequence generation with configurable depth and frequency thresholds
+- iVar variant calling with intrahost SNV (iSNV) detection
+- Nextclade sequence alignment (primary) with MAFFT fallback
+- Serotype assignment based on genome coverage metrics
+- Coverage profiling using bedtools genomecov
+- Results summarization across all samples
+- QC visualization plots (coverage vs Ct correlation, variant summaries)
+- MultiQC report aggregating all QC metrics
+- Configurable analysis parameters (min_depth, consensus_threshold, coverage_threshold, etc.)
+- External asset management for reference files
+- CI/CD workflows with nf-test integration
 
 ### `Dependencies`
 
+| Tool      | Version |
+| --------- | ------- |
+| BWA       | 0.7.18  |
+| bedtools  | 2.31.1  |
+| Falco     | 1.2.3   |
+| iVar      | 1.4.3   |
+| MAFFT     | 7.526   |
+| MultiQC   | 1.25.2  |
+| Nextclade | 3.10.2  |
+| SAMtools  | 1.21    |
+
+### `Fixed`
+
+- Falco module: Fixed paired-end read handling where outputs were overwriting each other (upstream nf-core bug)
+- SnakeYAML compatibility: Fixed yaml.load() to accept Nextflow Path objects on NF 25.x
+
 ### `Deprecated`
+
+- N/A

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -10,13 +10,37 @@
 
 ## Pipeline tools
 
+- [BWA](https://github.com/lh3/bwa)
+
+> Li H, Durbin R. Fast and accurate short read alignment with Burrows-Wheeler transform. Bioinformatics. 2009 Jul 15;25(14):1754-60. doi: 10.1093/bioinformatics/btp324. Epub 2009 May 18. PubMed PMID: 19451168; PubMed Central PMCID: PMC2705234.
+
+- [bedtools](https://github.com/arq5x/bedtools2)
+
+> Quinlan AR, Hall IM. BEDTools: a flexible suite of utilities for comparing genomic features. Bioinformatics. 2010 Mar 15;26(6):841-2. doi: 10.1093/bioinformatics/btq033. Epub 2010 Jan 28. PubMed PMID: 20110278; PubMed Central PMCID: PMC2832824.
+
 - [Falco](https://github.com/smithlabcode/falco)
 
 > de Sena Brandine G, Smith AD. Falco: high-speed FastQC emulation for quality control of sequencing data. F1000Research. 2019;8:1874. doi: 10.12688/f1000research.21142.2
 
+- [iVar](https://github.com/andersen-lab/ivar)
+
+> Grubaugh ND, Gangavarapu K, Quick J, Matteson NL, De Jesus JG, Main BJ, Tan AL, Paul LM, Brackney DE, Greber S, Lemey P, Holmes EC, Bedford T, Pybus OG, Jopling CL, Barnes KG, Saif L, Acevedo A, Andersen KG. An amplicon-based sequencing framework for accurately measuring intrahost virus diversity using PrimalSeq and iVar. Genome Biol. 2019 Jan 8;20(1):8. doi: 10.1186/s13059-018-1618-7. PubMed PMID: 30621750; PubMed Central PMCID: PMC6323615.
+
+- [MAFFT](https://mafft.cbrc.jp/alignment/software/)
+
+> Katoh K, Standley DM. MAFFT multiple sequence alignment software version 7: improvements in performance and usability. Mol Biol Evol. 2013 Apr;30(4):772-80. doi: 10.1093/molbev/mst010. Epub 2013 Jan 16. PubMed PMID: 23329690; PubMed Central PMCID: PMC3603318.
+
 - [MultiQC](https://pubmed.ncbi.nlm.nih.gov/27312411/)
 
 > Ewels P, Magnusson M, Lundin S, Käller M. MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics. 2016 Oct 1;32(19):3047-8. doi: 10.1093/bioinformatics/btw354. Epub 2016 Jun 16. PubMed PMID: 27312411; PubMed Central PMCID: PMC5039924.
+
+- [Nextclade](https://github.com/nextstrain/nextclade)
+
+> Aksamentov I, Roemer C, Hodcroft EB, Neher RA. Nextclade: clade assignment, mutation calling and quality control for viral genomes. J Open Source Softw. 2021;6(67):3773. doi: 10.21105/joss.03773
+
+- [SAMtools](https://github.com/samtools/samtools)
+
+> Danecek P, Bonfield JK, Liddle J, Marshall J, Ohan V, Pollard MO, Whitwham A, Keane T, McCarthy SA, Davies RM, Li H. Twelve years of SAMtools and BCFtools. Gigascience. 2021 Feb 16;10(2):giab008. doi: 10.1093/gigascience/giab008. PubMed PMID: 33590861; PubMed Central PMCID: PMC7931819.
 
 ## Software packaging/containerisation tools
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -2,19 +2,22 @@
 
 ## Introduction
 
-This document describes the output produced by the pipeline. Most of the plots are taken from the MultiQC report, which summarises results at the end of the pipeline.
-
-The directories listed below will be created in the results directory after the pipeline has finished. All paths are relative to the top-level results directory.
-
-<!-- TODO nf-core: Write this documentation describing your workflow's output -->
+This document describes the output produced by the pipeline. The directories listed below will be created in the results directory after the pipeline has finished. All paths are relative to the top-level results directory.
 
 ## Pipeline overview
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
 
 - [Falco](#falco) - Raw read QC
-- [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline
-- [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
+- [Alignment](#alignment) - Read alignment to reference
+- [Trimmed](#trimmed) - Primer-trimmed BAM files
+- [Consensus](#consensus) - Consensus sequences
+- [Variants](#variants) - Variant calls
+- [Coverage](#coverage) - Depth profiles
+- [Serotype calls](#serotype-calls) - Serotype assignments
+- [Results](#results) - Summary tables and QC plots
+- [MultiQC](#multiqc) - Aggregate report
+- [Pipeline information](#pipeline-information) - Execution metrics
 
 ### Falco
 
@@ -30,19 +33,113 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 
 [Falco](https://github.com/smithlabcode/falco) is a high-speed FastQC emulation tool that provides general quality metrics about your sequenced reads. It is 3x faster than FastQC while producing equivalent results. Falco provides information about the quality score distribution across your reads, per base sequence content (%A/T/G/C), adapter contamination and overrepresented sequences. The output is fully compatible with MultiQC's FastQC module.
 
+### Alignment
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `alignment/`
+  - `*.sorted.bam`: Sorted BAM file after primer trimming.
+  - `*.aln.fasta`: Aligned consensus sequence (from Nextclade or MAFFT).
+
+</details>
+
+Reads are aligned to each serotype reference using BWA-MEM. After primer trimming with iVar, the sorted BAM files are published for downstream analysis.
+
+### Trimmed
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `trimmed/`
+  - `*.trimmed.bam`: BAM files after iVar primer trimming.
+
+</details>
+
+[iVar](https://github.com/andersen-lab/ivar) trims primer sequences from aligned reads using amplicon-specific BED files. This step also performs Q20 sliding window quality trimming.
+
+### Consensus
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `consensus/`
+  - `*.cons.fa`: Consensus FASTA sequence for each sample-serotype combination.
+
+</details>
+
+Consensus sequences are generated using iVar consensus with configurable parameters:
+
+- `--min_depth`: Minimum read depth for base calling (default: 10)
+- `--consensus_threshold`: Minimum allele frequency (default: 0.75)
+
+Positions below the depth threshold are called as N.
+
+### Variants
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `variants/`
+  - `*.variants.tsv`: Raw variant calls from iVar variants.
+  - `*_variants_frequency.tsv`: Filtered variants with frequency annotations.
+
+</details>
+
+Variants are called using iVar variants and filtered based on the `--variant_threshold` parameter. The filtered output includes annotations for intrahost single nucleotide variants (iSNVs) based on the `--isnv_min_freq` and `--isnv_max_freq` thresholds.
+
+### Coverage
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `coverage/`
+  - `*.depth.txt`: Per-position depth profile from bedtools genomecov.
+
+</details>
+
+Depth profiles are generated using bedtools genomecov with the `-d` flag to report depth at each genomic position.
+
+### Serotype calls
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `serotype_calls/`
+  - `*.serotype_call.tsv`: Serotype assignment for each sample-serotype combination.
+
+</details>
+
+Each sample is analyzed against all configured serotypes. The serotype caller computes genome coverage and assigns serotypes based on the `--coverage_threshold` parameter.
+
+### Results
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `results/`
+  - `serotype_calls_summary.tsv`: Aggregated serotype assignments across all samples.
+  - `variants_summary.tsv`: Aggregated variant calls across all samples.
+  - `coverage_vs_ct.pdf`: Scatter plot of genome coverage vs Ct values (if Ct provided).
+  - `variants_by_sample.pdf`: Variant frequency plots by sample.
+
+</details>
+
+The results directory contains summary tables aggregating data across all samples, plus QC visualization plots when `--skip_qc` is false.
+
 ### MultiQC
 
 <details markdown="1">
 <summary>Output files</summary>
 
 - `multiqc/`
-  - `multiqc_report.html`: a standalone HTML file that can be viewed in your web browser.
-  - `multiqc_data/`: directory containing parsed statistics from the different tools used in the pipeline.
-  - `multiqc_plots/`: directory containing static images from the report in various formats.
+  - `multiqc_report.html`: A standalone HTML file that can be viewed in your web browser.
+  - `multiqc_data/`: Directory containing parsed statistics from the different tools used in the pipeline.
+  - `multiqc_plots/`: Directory containing static images from the report in various formats.
 
 </details>
 
-[MultiQC](http://multiqc.info) is a visualization tool that generates a single HTML report summarising all samples in your project. Most of the pipeline QC results are visualised in the report and further statistics are available in the report data directory.
+[MultiQC](http://multiqc.info) is a visualization tool that generates a single HTML report summarizing all samples in your project. Most of the pipeline QC results are visualized in the report and further statistics are available in the report data directory.
 
 Results generated by MultiQC collate pipeline QC from supported tools e.g. Falco (via FastQC module). The pipeline has special steps which also allow the software versions to be reported in the MultiQC output for future traceability. For more information about how to use MultiQC reports, see <http://multiqc.info>.
 
@@ -56,6 +153,7 @@ Results generated by MultiQC collate pipeline QC from supported tools e.g. Falco
   - Reports generated by the pipeline: `pipeline_report.html`, `pipeline_report.txt` and `software_versions.yml`. The `pipeline_report*` files will only be present if the `--email` / `--email_on_fail` parameter's are used when running the pipeline.
   - Reformatted samplesheet files used as input to the pipeline: `samplesheet.valid.csv`.
   - Parameters used by the pipeline run: `params.json`.
+  - `denver_software_mqc_versions.yml`: Software versions used in the pipeline run.
 
 </details>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,118 +1,146 @@
 # smagala/denver: Usage
 
-> _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
-
 ## Introduction
 
-<!-- TODO nf-core: Add documentation about anything specific to running your pipeline. For general topics, please point to (and add to) the main nf-core website. -->
+The denver pipeline is a Nextflow workflow for analyzing Dengue virus (DENV) sequencing data from amplicon-based protocols. It performs:
+
+- **Read quality control** using Falco (FastQC-compatible)
+- **Multi-serotype analysis** against DENV1-4 and sylvatic variants
+- **Primer trimming** using iVar with amplicon-specific BED files
+- **Consensus sequence generation** with configurable depth and frequency thresholds
+- **Variant calling** including intrahost single nucleotide variants (iSNVs)
+- **Sequence alignment** using Nextclade (primary) or MAFFT (fallback)
+- **Serotype assignment** based on genome coverage metrics
+- **QC visualization** with coverage plots and variant summaries
 
 ## Samplesheet input
 
-You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row as shown in the examples below.
+You will need to create a samplesheet with information about the samples you would like to analyze before running the pipeline. Use this parameter to specify its location:
 
 ```bash
 --input '[path to samplesheet file]'
 ```
 
-### Multiple runs of the same sample
+### Samplesheet format
 
-The `sample` identifiers have to be the same when you have re-sequenced the same sample more than once e.g. to increase sequencing depth. The pipeline will concatenate the raw reads before performing any downstream analysis. Below is an example for the same sample sequenced across 3 lanes:
+The samplesheet must be a comma-separated file with a header row. The required columns are:
+
+| Column    | Description                                                                                              |
+| --------- | -------------------------------------------------------------------------------------------------------- |
+| `sample`  | Sample identifier. Spaces are converted to underscores.                                                  |
+| `fastq_1` | Full path to FastQ file for read 1. Must be gzipped (`.fastq.gz` or `.fq.gz`).                           |
+| `fastq_2` | Full path to FastQ file for read 2 (optional for single-end). Must be gzipped (`.fastq.gz` or `.fq.gz`). |
+
+Optional columns:
+
+| Column | Description                                                       |
+| ------ | ----------------------------------------------------------------- |
+| `ct`   | Ct value from RT-qPCR. Used for QC correlation plots if provided. |
+
+### Example samplesheet
 
 ```csv title="samplesheet.csv"
-sample,fastq_1,fastq_2
-CONTROL_REP1,AEG588A1_S1_L002_R1_001.fastq.gz,AEG588A1_S1_L002_R2_001.fastq.gz
-CONTROL_REP1,AEG588A1_S1_L003_R1_001.fastq.gz,AEG588A1_S1_L003_R2_001.fastq.gz
-CONTROL_REP1,AEG588A1_S1_L004_R1_001.fastq.gz,AEG588A1_S1_L004_R2_001.fastq.gz
+sample,fastq_1,fastq_2,ct
+SAMPLE_001,/path/to/SAMPLE_001_R1.fastq.gz,/path/to/SAMPLE_001_R2.fastq.gz,18.5
+SAMPLE_002,/path/to/SAMPLE_002_R1.fastq.gz,/path/to/SAMPLE_002_R2.fastq.gz,22.3
+SAMPLE_003,/path/to/SAMPLE_003_R1.fastq.gz,/path/to/SAMPLE_003_R2.fastq.gz,
 ```
-
-### Full samplesheet
-
-The pipeline will auto-detect whether a sample is single- or paired-end using the information provided in the samplesheet. The samplesheet can have as many columns as you desire, however, there is a strict requirement for the first 3 columns to match those defined in the table below.
-
-A final samplesheet file consisting of both single- and paired-end data may look something like the one below. This is for 6 samples, where `TREATMENT_REP3` has been sequenced twice.
-
-```csv title="samplesheet.csv"
-sample,fastq_1,fastq_2
-CONTROL_REP1,AEG588A1_S1_L002_R1_001.fastq.gz,AEG588A1_S1_L002_R2_001.fastq.gz
-CONTROL_REP2,AEG588A2_S2_L002_R1_001.fastq.gz,AEG588A2_S2_L002_R2_001.fastq.gz
-CONTROL_REP3,AEG588A3_S3_L002_R1_001.fastq.gz,AEG588A3_S3_L002_R2_001.fastq.gz
-TREATMENT_REP1,AEG588A4_S4_L003_R1_001.fastq.gz,
-TREATMENT_REP2,AEG588A5_S5_L003_R1_001.fastq.gz,
-TREATMENT_REP3,AEG588A6_S6_L003_R1_001.fastq.gz,
-TREATMENT_REP3,AEG588A6_S6_L004_R1_001.fastq.gz,
-```
-
-| Column    | Description                                                                                                                                                                            |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sample`  | Custom sample name. This entry will be identical for multiple sequencing libraries/runs from the same sample. Spaces in sample names are automatically converted to underscores (`_`). |
-| `fastq_1` | Full path to FastQ file for Illumina short reads 1. File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                             |
-| `fastq_2` | Full path to FastQ file for Illumina short reads 2. File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                             |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
 
+## Reference files
+
+The pipeline requires DENV reference files organized in a specific directory structure:
+
+```
+references/
+├── refs.txt              # List of serotype names (one per line)
+├── DENV1.fasta           # Reference genome for DENV1
+├── DENV1.bed             # Primer BED file for DENV1
+├── DENV1.trim.bed        # Optional trim regions for DENV1
+├── DENV2.fasta
+├── DENV2.bed
+├── DENV2.trim.bed
+├── DENV3.fasta
+├── DENV3.bed
+├── DENV4.fasta
+├── DENV4.bed
+├── DENV2_sylvatic.fasta  # Sylvatic variant references
+├── DENV2_sylvatic.bed
+└── ...
+```
+
+The `refs.txt` file should list all serotypes to analyze:
+
+```
+DENV1
+DENV2
+DENV3
+DENV4
+DENV2_sylvatic
+DENV4_sylvatic
+```
+
 ## Running the pipeline
 
-The typical command for running the pipeline is as follows:
+The typical command for running the pipeline is:
 
 ```bash
-nextflow run smagala/denver --input ./samplesheet.csv --outdir ./results --genome GRCh37 -profile docker
+nextflow run smagala/denver \
+    --input samplesheet.csv \
+    --outdir results \
+    --references_base /path/to/references \
+    -profile docker
 ```
 
-This will launch the pipeline with the `docker` configuration profile. See below for more information about profiles.
+This will launch the pipeline with the `docker` configuration profile.
 
-Note that the pipeline will create the following files in your working directory:
+### DENV-specific parameters
+
+| Parameter               | Default | Description                                                  |
+| ----------------------- | ------- | ------------------------------------------------------------ |
+| `--references_base`     | -       | Path to directory containing DENV reference files            |
+| `--serotypes_file`      | -       | Path to refs.txt (defaults to `${references_base}/refs.txt`) |
+| `--min_depth`           | 10      | Minimum read depth for consensus base calling                |
+| `--consensus_threshold` | 0.75    | Minimum allele frequency for consensus (0-1)                 |
+| `--variant_threshold`   | 0.03    | Minimum frequency for variant calling (0-1)                  |
+| `--coverage_threshold`  | 0.5     | Minimum genome coverage for serotype assignment (0-1)        |
+| `--isnv_min_freq`       | 0.2     | Minimum frequency for iSNV detection (0-1)                   |
+| `--isnv_max_freq`       | 0.8     | Maximum frequency for iSNV detection (0-1)                   |
+| `--read_cap`            | 10000   | Maximum read depth for mpileup (speeds up high-coverage)     |
+| `--skip_qc`             | false   | Skip QC visualization plots                                  |
+
+### Example with parameters
 
 ```bash
-work                # Directory containing the nextflow working files
-<OUTDIR>            # Finished results in specified location (defined with --outdir)
-.nextflow_log       # Log file from Nextflow
-# Other nextflow hidden files, eg. history of pipeline runs and old logs.
+nextflow run smagala/denver \
+    --input samplesheet.csv \
+    --outdir results \
+    --references_base /data/denv_references \
+    --min_depth 20 \
+    --consensus_threshold 0.8 \
+    --coverage_threshold 0.6 \
+    -profile docker
 ```
 
-If you wish to repeatedly use the same parameters for multiple runs, rather than specifying each flag in the command, you can specify these in a params file.
+### Using a params file
 
-Pipeline settings can be provided in a `yaml` or `json` file via `-params-file <file>`.
+For reproducibility, you can specify parameters in a YAML file:
 
-> [!WARNING]
-> Do not use `-c <file>` to specify parameters as this will result in errors. Custom config files specified with `-c` must only be used for [tuning process resource specifications](https://nf-co.re/docs/usage/configuration#tuning-workflow-resources), other infrastructural tweaks (such as output directories), or module arguments (args).
+```yaml title="params.yaml"
+input: "./samplesheet.csv"
+outdir: "./results"
+references_base: "/data/denv_references"
+min_depth: 20
+consensus_threshold: 0.8
+coverage_threshold: 0.6
+```
 
-The above pipeline run specified with a params file in yaml format:
+Then run with:
 
 ```bash
 nextflow run smagala/denver -profile docker -params-file params.yaml
 ```
-
-with:
-
-```yaml title="params.yaml"
-input: './samplesheet.csv'
-outdir: './results/'
-genome: 'GRCh37'
-<...>
-```
-
-You can also generate such `YAML`/`JSON` files via [nf-core/launch](https://nf-co.re/launch).
-
-### Updating the pipeline
-
-When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:
-
-```bash
-nextflow pull smagala/denver
-```
-
-### Reproducibility
-
-It is a good idea to specify the pipeline version when running the pipeline on your data. This ensures that a specific version of the pipeline code and software are used when you run your pipeline. If you keep using the same tag, you'll be running the same version of the pipeline, even if there have been changes to the code since.
-
-First, go to the [smagala/denver releases page](https://github.com/smagala/denver/releases) and find the latest pipeline version - numeric only (eg. `1.3.1`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.3.1`. Of course, you can switch to another version by changing the number after the `-r` flag.
-
-This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future. For example, at the bottom of the MultiQC reports.
-
-To further assist in reproducibility, you can use share and reuse [parameter files](#running-the-pipeline) to repeat pipeline runs with the same settings without having to write out a command with every single parameter.
-
-> [!TIP]
-> If you wish to share such profile (such as upload as supplementary material for academic publications), make sure to NOT include cluster specific paths to files, nor institutional specific profiles.
 
 ## Core Nextflow arguments
 
@@ -123,90 +151,61 @@ To further assist in reproducibility, you can use share and reuse [parameter fil
 
 Use this parameter to choose a configuration profile. Profiles can give configuration presets for different compute environments.
 
-Several generic profiles are bundled with the pipeline which instruct the pipeline to use software packaged using different methods (Docker, Singularity, Podman, Shifter, Charliecloud, Apptainer, Conda) - see below.
+Several generic profiles are bundled with the pipeline which instruct the pipeline to use software packaged using different methods (Docker, Singularity, Podman, Shifter, Charliecloud, Apptainer, Conda):
 
-> [!IMPORTANT]
-> We highly recommend the use of Docker or Singularity containers for full pipeline reproducibility, however when this is not possible, Conda is also supported.
+- `docker` - Use Docker containers
+- `singularity` - Use Singularity containers
+- `podman` - Use Podman containers
+- `apptainer` - Use Apptainer containers
+- `conda` - Use Conda environments (not recommended)
+- `test` - Run with minimal test data
 
-The pipeline also dynamically loads configurations from [https://github.com/nf-core/configs](https://github.com/nf-core/configs) when it runs, making multiple config profiles for various institutional clusters available at run time. For more information and to check if your system is supported, please see the [nf-core/configs documentation](https://github.com/nf-core/configs#documentation).
-
-Note that multiple profiles can be loaded, for example: `-profile test,docker` - the order of arguments is important!
-They are loaded in sequence, so later profiles can overwrite earlier profiles.
-
-If `-profile` is not specified, the pipeline will run locally and expect all software to be installed and available on the `PATH`. This is _not_ recommended, since it can lead to different results on different machines dependent on the computer environment.
-
-- `test`
-  - A profile with a complete configuration for automated testing
-  - Includes links to test data so needs no other parameters
-- `docker`
-  - A generic configuration profile to be used with [Docker](https://docker.com/)
-- `singularity`
-  - A generic configuration profile to be used with [Singularity](https://sylabs.io/docs/)
-- `podman`
-  - A generic configuration profile to be used with [Podman](https://podman.io/)
-- `shifter`
-  - A generic configuration profile to be used with [Shifter](https://nersc.gitlab.io/development/shifter/how-to-use/)
-- `charliecloud`
-  - A generic configuration profile to be used with [Charliecloud](https://charliecloud.io/)
-- `apptainer`
-  - A generic configuration profile to be used with [Apptainer](https://apptainer.org/)
-- `wave`
-  - A generic configuration profile to enable [Wave](https://seqera.io/wave/) containers. Use together with one of the above (requires Nextflow ` 24.03.0-edge` or later).
-- `conda`
-  - A generic configuration profile to be used with [Conda](https://conda.io/docs/). Please only use Conda as a last resort i.e. when it's not possible to run the pipeline with Docker, Singularity, Podman, Shifter, Charliecloud, or Apptainer.
+Multiple profiles can be loaded: `-profile test,docker`
 
 ### `-resume`
 
-Specify this when restarting a pipeline. Nextflow will use cached results from any pipeline steps where the inputs are the same, continuing from where it got to previously. For input to be considered the same, not only the names must be identical but the files' contents as well. For more info about this parameter, see [this blog post](https://www.nextflow.io/blog/2019/demystifying-nextflow-resume.html).
+Specify this when restarting a pipeline. Nextflow will use cached results from any pipeline steps where the inputs are the same:
 
-You can also supply a run name to resume a specific run: `-resume [run-name]`. Use the `nextflow log` command to show previous run names.
+```bash
+nextflow run smagala/denver -profile docker -resume
+```
 
 ### `-c`
 
-Specify the path to a specific config file (this is a core Nextflow command). See the [nf-core website documentation](https://nf-co.re/usage/configuration) for more information.
-
-## Custom configuration
-
-### Resource requests
-
-Whilst the default requirements set within the pipeline will hopefully work for most people and with most input data, you may find that you want to customise the compute resources that the pipeline requests. Each step in the pipeline has a default set of requirements for number of CPUs, memory and time. For most of the pipeline steps, if the job exits with any of the error codes specified [here](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/conf/base.config#L18) it will automatically be resubmitted with higher resources request (2 x original, then 3 x original). If it still fails after the third attempt then the pipeline execution is stopped.
-
-To change the resource requests, please see the [max resources](https://nf-co.re/docs/usage/configuration#max-resources) and [tuning workflow resources](https://nf-co.re/docs/usage/configuration#tuning-workflow-resources) section of the nf-core website.
-
-### Custom Containers
-
-In some cases, you may wish to change the container or conda environment used by a pipeline steps for a particular tool. By default, nf-core pipelines use containers and software from the [biocontainers](https://biocontainers.pro/) or [bioconda](https://bioconda.github.io/) projects. However, in some cases the pipeline specified version maybe out of date.
-
-To use a different container from the default container or conda environment specified in a pipeline, please see the [updating tool versions](https://nf-co.re/docs/usage/configuration#updating-tool-versions) section of the nf-core website.
-
-### Custom Tool Arguments
-
-A pipeline might not always support every possible argument or option of a particular tool used in pipeline. Fortunately, nf-core pipelines provide some freedom to users to insert additional parameters that the pipeline does not include by default.
-
-To learn how to provide additional arguments to a particular tool of the pipeline, please see the [customising tool arguments](https://nf-co.re/docs/usage/configuration#customising-tool-arguments) section of the nf-core website.
-
-### nf-core/configs
-
-In most cases, you will only need to create a custom config as a one-off but if you and others within your organisation are likely to be running nf-core pipelines regularly and need to use the same settings regularly it may be a good idea to request that your custom config file is uploaded to the `nf-core/configs` git repository. Before you do this please can you test that the config file works with your pipeline of choice using the `-c` parameter. You can then create a pull request to the `nf-core/configs` repository with the addition of your config file, associated documentation file (see examples in [`nf-core/configs/docs`](https://github.com/nf-core/configs/tree/master/docs)), and amending [`nfcore_custom.config`](https://github.com/nf-core/configs/blob/master/nfcore_custom.config) to include your custom profile.
-
-See the main [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html) for more information about creating your own configuration files.
-
-If you have any questions or issues please send us a message on [Slack](https://nf-co.re/join/slack) on the [`#configs` channel](https://nfcore.slack.com/channels/configs).
-
-## Running in the background
-
-Nextflow handles job submissions and supervises the running jobs. The Nextflow process must run until the pipeline is finished.
-
-The Nextflow `-bg` flag launches Nextflow in the background, detached from your terminal so that the workflow does not stop if you log out of your session. The logs are saved to a file.
-
-Alternatively, you can use `screen` / `tmux` or similar tool to create a detached session which you can log back into at a later time.
-Some HPC setups also allow you to run nextflow within a cluster job submitted your job scheduler (from where it submits more jobs).
-
-## Nextflow memory requirements
-
-In some cases, the Nextflow Java virtual machines can start to request a large amount of memory.
-We recommend adding the following line to your environment to limit this (typically in `~/.bashrc` or `~./bash_profile`):
+Specify the path to a custom config file:
 
 ```bash
-NXF_OPTS='-Xms1g -Xmx4g'
+nextflow run smagala/denver -profile docker -c custom.config
 ```
+
+## Output
+
+See [output documentation](output.md) for a description of all output files.
+
+## Resource requirements
+
+The pipeline has default resource requirements set in `conf/base.config`. You can customize these in a custom config file:
+
+```groovy title="custom.config"
+process {
+    withName: 'BWA_MEM' {
+        cpus = 8
+        memory = 16.GB
+    }
+}
+```
+
+## Troubleshooting
+
+### Common issues
+
+1. **No serotype assigned**: Check that genome coverage meets the `--coverage_threshold` parameter. Low Ct samples may have insufficient coverage.
+
+2. **Missing reference files**: Ensure all serotypes listed in `refs.txt` have corresponding `.fasta` and `.bed` files in `references_base`.
+
+3. **Container errors**: Ensure Docker/Singularity is properly configured and images can be pulled.
+
+### Getting help
+
+- Check the [nf-core documentation](https://nf-co.re/docs/usage/introduction)
+- Open an issue on the [GitHub repository](https://github.com/smagala/denver/issues)


### PR DESCRIPTION
## Summary

Complete documentation updates for the v1.0.0 release:

- **usage.md**: Rewrote with DENV-specific content including pipeline introduction, samplesheet format, reference file structure, and all parameters
- **output.md**: Expanded to document all output directories (falco, alignment, trimmed, consensus, variants, coverage, serotype_calls, results)
- **CITATIONS.md**: Added missing citations for BWA, bedtools, iVar, MAFFT, Nextclade, SAMtools
- **CHANGELOG.md**: Updated with comprehensive v1.0.0 release notes including features, dependencies, and fixes

## Addresses Epic 6 Stories

- [x] 6.1 Write usage documentation
- [x] 6.2 Write output documentation
- [x] 6.4 Update CITATIONS.md
- [x] 6.7 Create CHANGELOG.md

## Already Complete (from previous work)

- [x] 6.3 nextflow_schema.json - already exists with DENV params
- [x] 6.5 MultiQC integration - already integrated
- [x] 6.6 nf-core lint - passes with 1 accepted failure (SnakeYAML fix)

## Test Plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify `nf-core pipelines lint` passes (1 expected failure)
- [ ] Verify `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)